### PR TITLE
chore: adds CCAI team to samples CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 *                       @googleapis/yoshi-java
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers
+samples/**/*.java       @googleapis/java-samples-reviewers @googleapis/api-contact-center-insights

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 *                       @googleapis/yoshi-java
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers @googleapis/api-contact-center-insights
+samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,9 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*                       @googleapis/yoshi-java
+# The @googleapis/api-contact-center-insights is the default owner for changes in this repo
+*                       @googleapis/yoshi-java @googleapis/api-contact-center-insights
+**/*.java               @googleapis/api-contact-center-insights
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers @googleapis/api-contact-center-insights
+samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,5 +11,6 @@
   "repo_short": "java-contact-center-insights",
   "distribution_name": "com.google.cloud:google-cloud-contact-center-insights",
   "api_id": "contactcenterinsights.googleapis.com",
-  "requires_billing": true
+  "requires_billing": true,
+  "codeowner_team": "@googleapis/api-contact-center-insights"
 }


### PR DESCRIPTION
This PR adds the @googleapis/api-contact-center-insights team to the CODEOWNERS file for the samples/ folder.