### PR TITLE
ci: removing api-contact-center-insights team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 *                       @googleapis/yoshi-java
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers
+samples/**/*.java       @googleapis/java-samples-reviewers @googleapis/api-contact-center-insights

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # The @googleapis/api-contact-center-insights is the default owner for changes in this repo
-*                       @googleapis/yoshi-java @googleapis/api-contact-center-insights
+*                       @googleapis/yoshi-java
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers @googleapis/api-contact-center-insights
+samples/**/*.java       @googleapis/java-samples-reviewers


### PR DESCRIPTION
As per email exchange with TrucHLe, removing api-contact-center-insights team from CODEOWNERS file
